### PR TITLE
Format diagnostic messages similar to linter-flake8

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -149,7 +149,7 @@ module.exports = {
                 }                
                 data.push({
                   severity: severity,
-                  linterName: "Ruff",
+                  linterName: "ruff",
                   excerpt: item.code === null ? item.message : `${item.code} — ${item.message}`,
                   location: { file: editorPath,
                     position: [

--- a/lib/main.js
+++ b/lib/main.js
@@ -146,11 +146,11 @@ module.exports = {
                 } else {
                   severity = 'error'
                   if (this.addStar) { item.code += '*' }
-                }
+                }                
                 data.push({
                   severity: severity,
-                  linterName: item.code,
-                  excerpt: item.message,
+                  linterName: "Ruff",
+                  excerpt: item.code === null ? item.message : `${item.code} — ${item.message}`,
                   location: { file: editorPath,
                     position: [
                       [item.location.row-1-hiddenlines, item.location.column-1],


### PR DESCRIPTION
A quick QoL change that will make the ruff lints play a little nicer like the flake8 ones do. The format is just copied directly from `linter-flake8`.

Putting `Ruff` as the linter name since this value doesn't get included in the hover text, and instead adding the item code to the excerpt message.
![image](https://github.com/user-attachments/assets/9a5318a5-2b2c-4c2c-9c56-e0d8447e9a7c)

Syntax Errors:
![image](https://github.com/user-attachments/assets/eb0e9b35-0a80-40a3-a16d-2aa29fe015c5)

You can now see the error code on hover:
![image](https://github.com/user-attachments/assets/5d82da91-7e3f-42da-8828-5ca749c7bf92)
